### PR TITLE
Add arm64 support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3 
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache bash build-base go ca-certificates curl git jq openssh"]
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash build-base go ca-certificates curl git jq openssh zip unzip"]
 
 COPY ["src", "/src/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3 
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache bash build-base ca-certificates curl git jq openssh"]
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash build-base go ca-certificates curl git jq openssh"]
 
 COPY ["src", "/src/"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM alpine:3 
 
-RUN ["/bin/sh", "-c", "apk add --update --no-cache bash ca-certificates curl git jq openssh"]
+RUN ["/bin/sh", "-c", "apk add --update --no-cache bash build-base ca-certificates curl git jq openssh"]
 
 COPY ["src", "/src/"]
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ Inputs configure Terraform GitHub Actions to perform different actions.
 | tf_actions_comment                  | Whether or not to comment on GitHub pull requests. Defaults to `true`. | `No` |
 | tf_actions_working_dir              | The working directory to change into before executing Terragrunt subcommands. Defaults to the root of the GitHub repository. | `No` |
 | tf_actions_fmt_write                | Whether or not to write `fmt` changes to source files. Defaults to `false`. | `No` |
+| tf_actions_architecture             | The architecture for running Terraform. Defaults to `amd64`. | `No` |
+| tg_actions_architecture             | The architecture for running Terragrunt. Defaults to `amd64`. | `No` |
 
 ## Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -1,47 +1,53 @@
-name: 'Terragrunt GitHub Actions'
-description: 'Runs Terragrunt commands via GitHub Actions.'
-author:  'HashiCorp, Inc. Terraform Team <terraform@hashicorp.com>'
+name: "Terragrunt GitHub Actions"
+description: "Runs Terragrunt commands via GitHub Actions."
+author: "HashiCorp, Inc. Terraform Team <terraform@hashicorp.com>"
 branding:
-  icon: 'cloud'
-  color: 'purple'
+  icon: "cloud"
+  color: "purple"
 inputs:
   tf_actions_subcommand:
-    description: 'Terraform or Terragrunt subcommand to execute.'
+    description: "Terraform or Terragrunt subcommand to execute."
     required: true
   tf_actions_binary:
-    description: 'Binary to use. Terraform or Terragrunt'
-    default: 'terragrunt'
+    description: "Binary to use. Terraform or Terragrunt"
+    default: "terragrunt"
   tf_actions_version:
-    description: 'Terraform version to install.'
+    description: "Terraform version to install."
     required: true
-    default: 'latest'
+    default: "latest"
   tg_actions_version:
-    description: 'Terragrunt version to install.'
+    description: "Terragrunt version to install."
     required: true
-    default: 'latest'
+    default: "latest"
   tf_actions_cli_credentials_hostname:
-    description: 'Hostname for the CLI credentials file.'
-    default: 'app.terraform.io'
+    description: "Hostname for the CLI credentials file."
+    default: "app.terraform.io"
   tf_actions_cli_credentials_token:
-    description: 'Token for the CLI credentials file.'
+    description: "Token for the CLI credentials file."
   tf_actions_comment:
-    description: 'Whether or not to comment on pull requests.'
+    description: "Whether or not to comment on pull requests."
     default: true
   tf_actions_working_dir:
-    description: 'Terragrunt working directory.'
-    default: '.'
+    description: "Terragrunt working directory."
+    default: "."
   tf_actions_fmt_write:
-    description: 'Write Terragrunt fmt changes to source files.'
+    description: "Write Terragrunt fmt changes to source files."
     default: false
+  tf_actions_architecture:
+    description: "The architecture for running Terraform."
+    default: "amd64"
+  tg_actions_architecture:
+    description: "The architecture for running Terragrunt."
+    default: "amd64"
 outputs:
   tf_actions_output:
-    description: 'The Terragrunt outputs in JSON format.'
+    description: "The Terragrunt outputs in JSON format."
   tf_actions_plan_has_changes:
-    description: 'Whether or not the Terragrunt plan contained changes.'
+    description: "Whether or not the Terragrunt plan contained changes."
   tf_actions_plan_output:
-    description: 'The Terragrunt plan output.'
+    description: "The Terragrunt plan output."
   tf_actions_fmt_written:
-    description: 'Whether or not the Terragrunt formatting was written to source files.'
+    description: "Whether or not the Terragrunt formatting was written to source files."
 runs:
-  using: 'docker'
-  image: './Dockerfile'
+  using: "docker"
+  image: "./Dockerfile"

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 function stripColors {
   echo "${1}" | sed 's/\x1b\[[0-9;]*m//g'
@@ -97,8 +98,8 @@ function installTerraform {
   fi
 
   url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
-
-  echo "Downloading Terraform v${tfVersion}"
+  
+  echo "Downloading Terraform v${tfVersion} (URL: ${url})"
   curl -s -S -L -o /tmp/terraform_${tfVersion} ${url}
   if [ "${?}" -ne 0 ]; then
     echo "Failed to download Terraform v${tfVersion}"

--- a/src/main.sh
+++ b/src/main.sh
@@ -51,6 +51,16 @@ function parseInputs {
     tfWorkingDir=${INPUT_TF_ACTIONS_WORKING_DIR}
   fi
 
+  tfArchitecture="amd64"
+  if [[ -n "${INPUT_TF_ACTIONS_ARCHITECTURE}" ]]; then
+    tfArchitecture=${INPUT_TF_ACTIONS_ARCHITECTURE}
+  fi
+
+  tgArchitecture="amd64"
+  if [[ -n "${INPUT_TG_ACTIONS_ARCHITECTURE}" ]]; then
+    tgArchitecture=${INPUT_TG_ACTIONS_ARCHITECTURE}
+  fi
+
   tfBinary="terragrunt"
   if [[ -n "${INPUT_TF_ACTIONS_BINARY}" ]]; then
     tfBinary=${INPUT_TF_ACTIONS_BINARY}
@@ -103,7 +113,7 @@ function installTerraform {
     fi
   fi
 
-  url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
+  url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_${tfArchitecture}.zip"
 
   echo "Downloading Terraform v${tfVersion} (URL: ${url})"
   curl -s -S -L -o /tmp/terraform_${tfVersion} ${url}
@@ -134,7 +144,7 @@ function installTerragrunt {
     fi
   fi
 
-  url="https://github.com/gruntwork-io/terragrunt/releases/download/${tgVersion}/terragrunt_linux_amd64"
+  url="https://github.com/gruntwork-io/terragrunt/releases/download/${tgVersion}/terragrunt_linux_${tgArchitecture}"
 
   echo "Downloading Terragrunt ${tgVersion}"
   curl -s -S -L -o /tmp/terragrunt ${url}

--- a/src/main.sh
+++ b/src/main.sh
@@ -155,6 +155,10 @@ function installTerragrunt {
 }
 
 function main {
+  # In Docker, Github actions mounts the Git repository in a way that breaks Terragrunt detection of the Git root
+  # Mark the mounted workspace as safe so Terragrunt built-in functions can detect Git root without problems
+  git config --global --add safe.directory $GITHUB_WORKSPACE
+
   # Source the other files to gain access to their functions
   echo "Loading terragrunt script modules"
   scriptDir=$(dirname ${0})

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,5 +1,12 @@
 #!/bin/bash
 
+############
+# Do not set -e on this script. The terragrunt script modules leverage
+# various exit codes as a means to communicate state.
+# Please see: https://www.terraform.io/docs/cli/commands/plan.html#detailed-exitcode
+#
+############
+
 function stripColors {
   echo "${1}" | sed 's/\x1b\[[0-9;]*m//g'
 }

--- a/src/main.sh
+++ b/src/main.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-set -e
 
 function stripColors {
   echo "${1}" | sed 's/\x1b\[[0-9;]*m//g'
@@ -98,7 +97,7 @@ function installTerraform {
   fi
 
   url="https://releases.hashicorp.com/terraform/${tfVersion}/terraform_${tfVersion}_linux_amd64.zip"
-  
+
   echo "Downloading Terraform v${tfVersion} (URL: ${url})"
   curl -s -S -L -o /tmp/terraform_${tfVersion} ${url}
   if [ "${?}" -ne 0 ]; then
@@ -140,7 +139,7 @@ function installTerragrunt {
 
   echo "Moving Terragrunt ${tgVersion} to PATH"
   chmod +x /tmp/terragrunt
-  mv /tmp/terragrunt /usr/local/bin/terragrunt 
+  mv /tmp/terragrunt /usr/local/bin/terragrunt
   if [ "${?}" -ne 0 ]; then
     echo "Failed to move Terragrunt ${tgVersion}"
     exit 1
@@ -150,9 +149,10 @@ function installTerragrunt {
 
 function main {
   # Source the other files to gain access to their functions
-  scriptDir=$(dirname ${0})  
+  echo "Loading terragrunt script modules"
+  scriptDir=$(dirname ${0})
   source ${scriptDir}/terragrunt_fmt.sh
-  source ${scriptDir}/terragrunt_hclfmt.sh  
+  source ${scriptDir}/terragrunt_hclfmt.sh
   source ${scriptDir}/terragrunt_init.sh
   source ${scriptDir}/terragrunt_validate.sh
   source ${scriptDir}/terragrunt_plan.sh

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -4,6 +4,9 @@ function terragruntApply {
   # Gather the output of `terragrunt apply`.
   echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
   applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
+  
+  echo "apply: info: output from Terragrunt apply: ${applyOutput}"
+  
   applyExitCode=${?}
   applyCommentStatus="Failed"
 

--- a/src/terragrunt_apply.sh
+++ b/src/terragrunt_apply.sh
@@ -5,9 +5,10 @@ function terragruntApply {
   echo "apply: info: applying Terragrunt configuration in ${tfWorkingDir}"
   applyOutput=$(${tfBinary} apply -auto-approve -input=false ${*} 2>&1)
   
+  applyExitCode=${?}
+
   echo "apply: info: output from Terragrunt apply: ${applyOutput}"
   
-  applyExitCode=${?}
   applyCommentStatus="Failed"
 
   # Exit code of 0 indicates success. Print the output and exit.


### PR DESCRIPTION
@nayyara-cropsey I added this version to support some Arm64 stuff we're doing in the Labs repo to support the newer Graviton processors.  I made sure to default the `amd64` you already had. I added an `arm64` tag and cut the `arm64` release so I could use that in the labs repo. 
